### PR TITLE
catch unknown roles

### DIFF
--- a/src/sso.rs
+++ b/src/sso.rs
@@ -350,6 +350,8 @@ struct AdditionnalClaims {
 pub enum UserRole {
     Admin,
     User,
+    #[serde(other)]
+    UNKNOWN,
 }
 
 #[derive(


### PR DESCRIPTION
one possibility to address:

https://github.com/Timshel/OIDCWarden/issues/22
https://github.com/Timshel/vaultwarden/issues/93


instead of UNKNOWN it could also be defaulted to User.