### PR TITLE
Added: NixOS install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ Docker images available at:
  - Docker hub [hub.docker.com/r/timshel/oidcwarden](https://hub.docker.com/r/timshel/oidcwarden/tags)
  - Github container registry [ghcr.io/timshel/oidcwarden](https://github.com/Timshel/oidcwarden/pkgs/container/oidcwarden)
 
+## NixOS
+
+A nixpkgs is available maintained by [@DerGrumpf](https://github.com/DerGrumpf)
+
+OIDCWarden can be used with the existing [vaultwarden service](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/security/vaultwarden/default.nix) defined in [nixpkgs](https://github.com/NixOS/nixpkgs).
+
+Just set the package option to: 
+```nix 
+services.vaultwarden.package = pkgs.oidcwarden;
+```
+
 ### Front-end version
 
 By default front-end version is fixed to prevent regression (check [CHANGELOG.md](CHANGELOG.md)).


### PR DESCRIPTION
Hi,

i've made a PR to Nixpkgs, to add OIDCWarden as a package. In the future I will maintain it there. 
The trick im using is, that the existing Infrastructure for vaultwarden can be used, so OIDCWarden is just a Drop-in Replacement.

The PR can be looked here: https://github.com/NixOS/nixpkgs/pull/529851

I would be Happy if this PR gets merged after the package got accepted into nix.

If the test doesn't suite your style of writing or you have any other complains just tell me and I'm happy to sort it out. :) 

Best regards